### PR TITLE
Demo fixes

### DIFF
--- a/examples/textEdit/Draw.mo
+++ b/examples/textEdit/Draw.mo
@@ -1,4 +1,6 @@
 import List "mo:base/List";
+import Iter "mo:base/Iter";
+import Nat "mo:base/Nat";
 import Result "mo:base/Result";
 import Render "mo:redraw/Render";
 import Mono5x5 "mo:redraw/glyph/Mono5x5";
@@ -10,17 +12,29 @@ import Stream "mo:sequence/Stream";
 
 module {
 
-  public type State = Types.State;
+  type State = Types.State;
 
-  // Flow atts --------------------------------------------------------
+  // (Spacing for blocks)-------------------------------------
 
   let horz : Render.FlowAtts = {
+    dir=#right;
+    interPad=2;
+    intraPad=2;
+  };
+
+  let vert : Render.FlowAtts = {
+    dir=#down;
+    interPad=2;
+    intraPad=2;
+  };
+
+  let tinyHorz : Render.FlowAtts = {
     dir=#right;
     interPad=1;
     intraPad=1;
   };
 
-  let vert : Render.FlowAtts = {
+  let tinyVert : Render.FlowAtts = {
     dir=#down;
     interPad=1;
     intraPad=1;
@@ -32,88 +46,72 @@ module {
     intraPad=zoom;
   } };
 
-  // Char/Text atts --------------------------------------------------------
+  // (Color and spacing for text)--------------------------------------------
 
-  type Atts = {
-    zoom:Nat;
-    fgFill:Render.Fill;
-    bgFill:Render.Fill
-  };
+  type Atts = Render.BitMapTextAtts;
 
-  func attsFgBg(fg:Render.Fill, bg:Render.Fill) : Atts =
-    {
-      zoom=4;
-      fgFill=fg;
-      bgFill=bg;
-    };
+  type TxtElm = {#colorZoom:((Nat, Nat, Nat), Nat); #lo; #hi; #h3};
 
-  func taTitleText(lineNo : Nat) : Atts =
-    switch lineNo {
-    case 0 {
-           zoom=4;
-           fgFill=#closed((255, 255, 255));
-           bgFill=#closed((0, 0, 0));
+  func txtSty(txtElm : TxtElm) : Atts = {
+    switch txtElm {
+    case (#colorZoom(c, z)) {
+           zoom=z;
+           fgFill=#closed(c);
+           bgFill=#none;
+           flow=horzText(z);
          };
-    case 1 {
+    case (#lo) {
+           zoom=1;
+           fgFill=#closed((200, 200, 200));
+           bgFill=#none;
+           flow=horzText(1);
+         };
+    case (#hi) {
+           zoom=1;
+           fgFill=#closed((240, 240, 240));
+           bgFill=#none;
+           flow=horzText(1);
+         };
+    case (#h3) {
            zoom=2;
-           fgFill=#closed((220, 220, 220));
-           bgFill=#closed((0, 0, 0));
-         };
-    case 2 {
-           zoom=2;
-           fgFill=#closed((150, 150, 150));
-           bgFill=#closed((0, 0, 0));
-         };
-    case _ {
-           zoom=3;
-           fgFill=#closed((255, 255, 255));
-           bgFill=#closed((0, 0, 0));
-         };
-  };
-
-  func textAtts(fg : Render.Color) : Atts =
-    attsFgBg(#closed(fg), #closed((0, 0, 0)));
-
-  func cursorAtts(st : State) : Atts {
-    switch (st.currentEvent) {
-    case null {
-           attsFgBg(#closed((255, 255, 255)), #closed((0, 0, 0)));
-         };
-    case (?ev) {
-           attsFgBg(#closed(ev.userInfo.textColor.0), #closed((0, 0, 0)));
+           fgFill=#closed((250, 250, 250));
+           bgFill=#none;
+           flow=horzText(2);
          };
     }
   };
 
-  public func drawEvent(ev : Types.EventInfo) : Render.Elm {
+  func cursorAtts(st : State) : Atts {
+    switch (st.currentEvent) {
+    case null { txtSty(#colorZoom((255, 255, 255), 2)) };
+    case (?ev) { txtSty(#colorZoom(ev.userInfo.textColor.0, 2)) };
+    }
+  };
+
+  /// -----------------------------------------------
+  func drawEvent(ev : Types.EventInfo) : Render.Elm {
     let r = Render.Render();
-    let cr = Render.CharRender(r, Mono5x5.bitmapOfChar,
-                               {
-                                 zoom = 1;
-                                 fgFill = #closed((255, 255, 255));
-                                 bgFill = #closed((0, 0, 0));
-                                 flow = horzText(1);
-                               });
+    let cr = Render.CharRender(r, Mono5x5.bitmapOfChar, txtSty(#lo));
     let tr = Render.TextRender(cr);
     r.begin(#flow(vert));
-    r.fill(#open((100, 100, 100), 1));
+    r.fill(#open((60, 20, 60), 1));
     r.begin(#flow(horz));
-    tr.textAtts(ev.dateTimeUtc # " ", taTitleText(2));
-    tr.textAtts(ev.userInfo.userName, taTitleText(2));
+    tr.textAtts(ev.dateTimeUtc # " ", txtSty(#lo));
+    tr.textAtts(ev.userInfo.userName, txtSty(#lo));
     r.rect({pos={x=0; y=0}; dim={width=10; height=10}},
            #closed(ev.userInfo.textColor.0));
     r.rect({pos={x=0; y=0}; dim={width=10; height=10}}, #none);
     switch (ev.event) {
-    case (#quit) tr.textAtts("quit", taTitleText(1));
-    case (#skip) tr.textAtts("skip", taTitleText(1));
-    case (#mouseDown(pos)) tr.textAtts("mouseDown(...)", taTitleText(1));
+    case (#quit) tr.textAtts("quit", txtSty(#lo));
+    case (#skip) tr.textAtts("skip", txtSty(#lo));
+    case (#mouseDown(pos)) tr.textAtts("mouseDown(...)", txtSty(#lo));
     case (#keyDown(ks)) {
-           tr.textAtts("keyDown ", taTitleText(1));
+           tr.textAtts("keyDown ", txtSty(#lo));
            for (k in ks.vals()) {
-             tr.textAtts(k.key # " ", taTitleText(2));
+             tr.textAtts(k.key # " ", txtSty(#lo));
            };
          };
-    case x { tr.textAtts("??? to do.", taTitleText(1)) };
+    case x { tr.textAtts("??? to do.", txtSty(#lo)) };
     };
     r.end();
     r.end();
@@ -121,45 +119,79 @@ module {
   };
 
   /// --------------------------------------------------------------------
-  public func drawCommitLog(st : State) : Render.Elm {
+  func drawCommitLog(st : State) : Render.Elm {
     let r = Render.Render();
-    let cr = Render.CharRender(r, Mono5x5.bitmapOfChar,
-                        {
-                          zoom = 1;
-                          fgFill = #closed((255, 255, 255));
-                          bgFill = #closed((0, 0, 0));
-                          flow = horzText(1);
-                        });
+    let cr = Render.CharRender(r, Mono5x5.bitmapOfChar, txtSty(#lo));
     let tr = Render.TextRender(cr);
     r.begin(#flow(vert));
-    r.fill(#open((255, 255, 0), 1));
+    r.fill(#open((200, 100, 220), 1));
     {
-      tr.textAtts("Developer view", taTitleText(1));
+      tr.textAtts("Developer view", txtSty(#lo));
       {
         r.begin(#flow(vert));
-        tr.textAtts(" Commit log:", taTitleText(1));
+        tr.textAtts("Commit log:", txtSty(#lo));
+        r.begin(#flow(horz));
+        r.rect({pos={x=0; y=0}; dim={width=10; height=10}}, #none);
         r.begin(#flow(vert));
-        for (ev in st.commitLog.vals()) {
-          r.elm(drawEvent(ev));
+
+        let maxShown = 8;
+
+        var i =
+          if (st.commitLog.size() > maxShown) st.commitLog.size() - maxShown
+          else 0;
+
+        let evs =
+          List.reverse(
+            List.take(
+              List.reverse(
+                Iter.toList(st.commitLog.vals())
+              ),
+              maxShown)
+          );
+
+        if (i != 0) {
+          r.begin(#flow(horz));
+          {
+            tr.textAtts(Nat.toText(st.commitLog.size() - maxShown), txtSty(#hi));
+            tr.textAtts(" earlier events, followed by...", txtSty(#lo));
+          };
+          r.end();
         };
+        for (ev in Iter.fromList(evs)) {
+          i += 1;
+          r.begin(#flow(horz));
+          r.begin(#flow(horz));
+          r.fill(#open((100, 100, 100), 1));
+          r.begin(#flow(horz));
+          r.fill(#open((10, 10, 10), 1));
+          tr.textAtts(Nat.toText(i), txtSty(#lo));
+          r.end();
+          r.end();
+          r.elm(drawEvent(ev));
+          r.end();
+        };
+        r.end();
         r.end();
         switch (st.currentEvent) {
           case null { };
           case (?ev) {
                  r.begin(#flow(horz));
-                 tr.textAtts(" View for ", taTitleText(1));
-                 tr.textAtts(ev.userInfo.userName, taTitleText(1));
+                 tr.textAtts("View for ", txtSty(#lo));
+                 tr.textAtts(ev.userInfo.userName, txtSty(#lo));
                  r.rect({pos={x=0; y=0}; dim={width=10; height=10}},
                         #closed(ev.userInfo.textColor.0));
                  r.end()
                }
         };
+        r.begin(#flow(horz));
+        r.rect({pos={x=0; y=0}; dim={width=10; height=10}}, #none);
         r.begin(#flow(vert));
         for (ev in st.viewEvents.vals()) {
           r.elm(drawEvent(ev));
         };
         r.end();
         r.end();
+        r.end();
       };
     };
     r.end();
@@ -167,91 +199,85 @@ module {
   };
 
   /// --------------------------------------------------------------------
-  public func drawState(st : State, windowDim : Render.Dim) : Render.Elm {
-
+  func drawUsers(st : State) : Render.Elm {
     let r = Render.Render();
-    let cr = Render.CharRender(r, Mono5x5.bitmapOfChar,
-                        {
-                          zoom = 3;
-                          fgFill = #closed((255, 255, 255));
-                          bgFill = #closed((0, 0, 0));
-                          flow = horzText(3);
-                        });
+    let cr = Render.CharRender(r, Mono5x5.bitmapOfChar, txtSty(#lo));
     let tr = Render.TextRender(cr);
 
-    r.begin(#flow(horz));  // Outer Display begin
-    r.begin(#flow(vert));  // Inner Display begin
-    r.fill(#open((255, 255, 0), 1));
-
+    r.begin(#flow(vert));
     {
-      r.begin(#flow(vert));
-      r.fill(#open((255, 255, 255), 1));
+      r.begin(#flow(horz));
       {
-        tr.textAtts("IC-EDIT", taTitleText(0));
-        tr.textAtts(" a multi-user text editor,", taTitleText(1));
-        tr.textAtts(" via Motoko and the Internet Computer", taTitleText(2));
-        tr.textAtts("-------------------------------------", taTitleText(2));
-      };
-      {
-        r.begin(#flow(horz));
-        tr.textAtts("User ", taTitleText(3));
+        tr.textAtts("Editing now as ", txtSty(#lo));
         switch (st.currentEvent) {
-          case null tr.textAtts("?", taTitleText(3));
-          case (?ev) {
-                 tr.textAtts(ev.userInfo.userName, taTitleText(3));
-               };
+        case null tr.textAtts("?", txtSty(#lo));
+        case (?ev) {
+               tr.textAtts(ev.userInfo.userName, txtSty(#lo));
+             };
         };
         switch (st.currentEvent) {
-          case null { };
-          case (?ev) {
-                 tr.textAtts(" as ", taTitleText(2));
-                 // draw a rectangle with their text color, a la Etherpad UI.
-                 r.rect({pos={x=0; y=0}; dim={width=15; height=15}},
-                        #closed(ev.userInfo.textColor.0));
-               };
-        };
-        r.end();
-      };
-      {
-        func getContentInfo(elm : ?Types.Elm) : (Text, Text, Render.Color) = {
-          switch elm {
-          case null ("none", "no one", (0, 0, 0));
-          case (?(#text(te))) { (te.lastModifyTime, te.lastModifyUser, te.color) };
-          }
-        };
-        let ((timeBefore, userBefore, colorBefore),
-             (timeAfter, userAfter, colorAfter)) = (
-          getContentInfo(Seq.peekBack(st.bwd)),
-          getContentInfo(Seq.peekFront(st.fwd)),
-        );
-        {
-          r.begin(#flow(vert));
-          tr.textAtts("Meta info: ", taTitleText(2));
-          {
-            r.begin(#flow(horz));
-            tr.textAtts("* back: ", taTitleText(2));
-            tr.textAtts(timeBefore, taTitleText(2));
-            tr.textAtts(" by ", taTitleText(2));
-            tr.textAtts(userBefore, taTitleText(2));
-            r.rect({pos={x=0; y=0}; dim={width=10; height=10}},
-                   #closed(colorBefore));
-            r.end();
-          };
-          {
-            r.begin(#flow(horz));
-            tr.textAtts("* forw: ", taTitleText(2));
-            tr.textAtts(timeAfter, taTitleText(2));
-            tr.textAtts(" by ", taTitleText(2));
-            tr.textAtts(userAfter, taTitleText(2));
-            r.rect({pos={x=0; y=0}; dim={width=10; height=10}},
-                   #closed(colorAfter));
-            r.end();
-          };
-          r.end();
+        case null { };
+        case (?ev) {
+               tr.textAtts(" with ", txtSty(#lo));
+               // draw a rectangle with their text color, a la Etherpad UI.
+               r.rect({pos={x=0; y=0}; dim={width=15; height=15}},
+                      #closed(ev.userInfo.textColor.0));
+             };
         };
       };
       r.end();
+
+
+      func getContentInfo(elm : ?Types.Elm) : (Text, Text, Render.Color) = {
+        switch elm {
+        case null ("none", "no one", (0, 0, 0));
+        case (?(#text(te))) { (te.lastModifyTime, te.lastModifyUser, te.color) };
+        }
+      };
+      let ((timeBefore, userBefore, colorBefore),
+           (timeAfter, userAfter, colorAfter)) = (
+        getContentInfo(Seq.peekBack(st.bwd)),
+        getContentInfo(Seq.peekFront(st.fwd)),
+      );
+
+      r.begin(#flow(tinyVert));
+      {
+        tr.textAtts("Content info: ", txtSty(#lo));
+        {
+          r.begin(#flow(tinyHorz));
+          {
+            tr.textAtts("* before cursor: ", txtSty(#lo));
+            tr.textAtts(timeBefore, txtSty(#hi));
+            tr.textAtts(" by ", txtSty(#lo));
+            tr.textAtts(userBefore, txtSty(#hi));
+            r.rect({pos={x=0; y=0}; dim={width=10; height=10}},
+                   #closed(colorBefore));
+          };
+          r.end();
+        };
+        r.begin(#flow(tinyHorz));
+        {
+          tr.textAtts("* after cursor: ", txtSty(#lo));
+          tr.textAtts(timeAfter, txtSty(#hi));
+          tr.textAtts(" by ", txtSty(#lo));
+          tr.textAtts(userAfter, txtSty(#hi));
+          r.rect({pos={x=0; y=0}; dim={width=10; height=10}},
+                 #closed(colorAfter));
+        };
+        r.end();
+      };
+      r.end();
     };
+    r.end();
+    r.getElm()
+  };
+
+  /// -----------------------------------------------
+  func drawContent(st : State) : Render.Elm {
+    let r = Render.Render();
+    let cr = Render.CharRender(r, Mono5x5.bitmapOfChar, txtSty(#lo));
+    let tr = Render.TextRender(cr);
+
     func isNewline(elm : Types.Elm) : Bool = {
       switch elm {
         case (#text(te)) { te.text == "\n" };
@@ -262,8 +288,13 @@ module {
       Seq.tokens(st.bwd, isNewline, st.levels),
       Seq.tokens(st.fwd, isNewline, st.levels),
     );
+
+    r.begin(#flow(horz));
+    r.fill(#open((200, 200, 200), 1));
+    {
     r.begin(#flow(vert));
     {
+      // draw the text buffer content, including the visible cursor(s)
       r.begin(#flow(horz));
       for (line in Seq.iter(linesBefore, #fwd)) {
         r.end();
@@ -271,27 +302,31 @@ module {
         for (elm in Seq.iter(line, #fwd)) {
           switch elm {
           case (#text(te)) {
-                 tr.textAtts(te.text, textAtts(te.color));
+                 tr.textAtts(te.text, txtSty(#colorZoom(te.color, 2)));
                };
           };
         };
       };
-      // edge case: newline char is immediately to left of cursor (begin next line)
-      switch (Seq.peekBack(st.bwd)) {
-      case (?lastChar) {
-             if (isNewline(lastChar)) {
-               r.end();
-               r.begin(#flow(horz));
+      {
+        /* detect an edge case: (to do: another "view representation" that obviates this logic.)
+           newline char is immediately to left of cursor.
+           if so, put cursor on next line, not dangling after (invisible) newline char. */
+        switch (Seq.peekBack(st.bwd)) {
+        case (?lastChar) {
+               if (isNewline(lastChar)) {
+                 r.end();
+                 r.begin(#flow(horz));
+               };
              };
-           };
-      case _ { };
+        case _ { };
+        };
       };
       tr.textAtts("*", cursorAtts(st));
       for (line in Seq.iter(linesAfter, #fwd)) {
         for (elm in Seq.iter(line, #fwd)) {
           switch elm {
           case (#text(te)) {
-                 tr.textAtts(te.text, textAtts(te.color));
+                 tr.textAtts(te.text, txtSty(#colorZoom(te.color, 2)));
                };
           };
         };
@@ -301,12 +336,61 @@ module {
       r.end();
     };
     r.end(); // Vertical end
-    r.end(); // Inner Display end
-
-    r.elm(drawCommitLog(st)); // Commit log, for developers.
-
-    r.end(); // Outer Display end
+    };
+    r.end();
     r.getElm()
+  };
+
+  /// --------------------------------------------------------------------
+  func drawTitle(st : State) : Render.Elm {
+    let r = Render.Render();
+    let cr = Render.CharRender(r, Mono5x5.bitmapOfChar, txtSty(#lo));
+    let tr = Render.TextRender(cr);
+
+    r.begin(#flow(vert));
+    r.fill(#open((255, 255, 0), 1));
+    {
+      r.begin(#flow(vert));
+      r.fill(#open((255, 255, 255), 1));
+      {
+        tr.textAtts("IC-EDIT", txtSty(#lo));
+        tr.textAtts(" a multi-user text editor,", txtSty(#lo));
+        tr.textAtts(" via Motoko and the Internet Computer", txtSty(#lo));
+      };
+      r.end();
+    };
+    r.end();
+    r.getElm()
+  };
+
+  /// --------------------------------------------------------------------
+  func drawMainWindow(st : State, windowDim : Render.Dim) : Render.Elm {
+    let r = Render.Render();
+    let cr = Render.CharRender(r, Mono5x5.bitmapOfChar, txtSty(#lo));
+    let tr = Render.TextRender(cr);
+
+    r.begin(#flow(vert)); // Two rows in view, each with two "blocks":
+    {
+      r.begin(#flow(horz)); // Row 1: Title block and Users block
+      {
+        r.elm(drawTitle(st));
+        r.elm(drawUsers(st)); // All users.
+      };
+      r.end();
+      r.begin(#flow(horz)); // Row 2: Content block and Developer info (events)
+      {
+        r.elm(drawContent(st));
+        r.elm(drawCommitLog(st));
+      };
+      r.end();
+    };
+    r.end();
+    r.getElm()
+  };
+
+  /// --------------------------------------------------------------------
+  public func drawState(st : State, windowDim : Render.Dim) : Render.Elm {
+    drawMainWindow(st, windowDim)
   };
 
 }

--- a/src/bin/ic-gt.rs
+++ b/src/bin/ic-gt.rs
@@ -366,6 +366,7 @@ fn translate_system_event(event: &SysEvent) -> Option<event::Event> {
                 Keycode::Underscore => "_".to_string(),
                 Keycode::Exclaim => "!".to_string(),
                 Keycode::Hash => "#".to_string(),
+                Keycode::Backquote => (if shift { "~" } else { "`" }).to_string(),
                 Keycode::Quote => (if shift { "\"" } else { "'" }).to_string(),
                 Keycode::Quotedbl => "\"".to_string(),
                 Keycode::LeftBracket => (if shift { "{" } else { "[" }).to_string(),
@@ -373,17 +374,6 @@ fn translate_system_event(event: &SysEvent) -> Option<event::Event> {
 
                 /* More to consider later (among many more that are available, but we will ignore)
                 Escape
-                Dollar
-                Percent
-                Ampersand
-                LeftParen
-                RightParen
-                Asterisk
-                Plus
-                Minus
-                Equals
-                Caret
-                Backquote
                 CapsLock
                 F1
                 F2

--- a/src/bin/ic-gt.rs
+++ b/src/bin/ic-gt.rs
@@ -349,6 +349,7 @@ fn translate_system_event(event: &SysEvent) -> Option<event::Event> {
                 Keycode::W => (if shift { "W" } else { "w" }).to_string(),
                 Keycode::X => (if shift { "X" } else { "x" }).to_string(),
                 Keycode::Y => (if shift { "Y" } else { "y" }).to_string(),
+                Keycode::Z => (if shift { "Z" } else { "z" }).to_string(),
                 Keycode::Equals => (if shift { "+" } else { "=" }).to_string(),
                 Keycode::Plus => "+".to_string(),
                 Keycode::Slash => (if shift { "?" } else { "/" }).to_string(),
@@ -412,7 +413,7 @@ fn translate_system_event(event: &SysEvent) -> Option<event::Event> {
             };
             let event = event::Event::KeyDown(vec![event::KeyEventInfo {
                 key: key,
-                // to do -- translate modifier keys,
+                /* to do -- include modifier keys' state here */
                 alt: false,
                 ctrl: false,
                 meta: false,

--- a/src/bin/ic-gt.rs
+++ b/src/bin/ic-gt.rs
@@ -606,15 +606,17 @@ async fn event_loop<T: RenderTarget>(
                         date_time_utc: Utc::now().to_rfc3339(),
                         event: event::Event::KeyDown(keys.clone())
                     });
-                    let rr: render::Result = {
-                        let mut buffer = u_key_infos.clone();
-                        buffer.append(&mut (q_key_infos.clone()));
-                        let rr =
-                            server_call(&cfg, ServerCall::View(window_dim.clone(), buffer.clone()))
+                    /* to do -- move downward, after collecting all waiting events */ {
+                        let rr: render::Result = {
+                            let mut buffer = u_key_infos.clone();
+                            buffer.append(&mut (q_key_infos.clone()));
+                            let rr =
+                                server_call(&cfg, ServerCall::View(window_dim.clone(), buffer.clone()))
                                 .await?;
-                        rr.unwrap()
-                    };
-                    redraw(canvas, &window_dim, &rr).await?;
+                            rr.unwrap()
+                        };
+                        redraw(canvas, &window_dim, &rr).await?;
+                    }
                 }
             }
         };
@@ -717,7 +719,8 @@ pub async fn server_call(
         "server_call: to canister_id {:?} at replica_url {:?}",
         cfg.canister_id, cfg.replica_url
     );
-    let canister_id = Principal::from_text(cfg.canister_id.clone()).unwrap(); // xxx
+    let canister_id = Principal::from_text(cfg.canister_id.clone()).unwrap();
+    /* to do -- make one agent and save it in a new structure, ConnectCtx, which holds a copy of the ConnectConfig we have here. */
     let agent = agent(&cfg.replica_url)?;
     let delay = Delay::builder()
         .throttle(RETRY_PAUSE)

--- a/src/bin/ic-gt.rs
+++ b/src/bin/ic-gt.rs
@@ -375,29 +375,11 @@ fn translate_system_event(event: &SysEvent) -> Option<event::Event> {
                 Keycode::LeftBracket => (if shift { "{" } else { "[" }).to_string(),
                 Keycode::RightBracket => (if shift { "}" } else { "]" }).to_string(),
 
-                /* More to consider later (among many more that are available, but we will ignore)
-                Escape
-                CapsLock
-                F1
-                F2
-                F3
-                F4
-                F5
-                F6
-                F7
-                F8
-                F9
-                F10
-                F11
-                F12
-                LCtrl
-                LShift
-                LAlt
-                LGui
-                RCtrl
-                RShift
-                RAlt
-                RGui
+                /* More to consider later (but can we capture these in a browser?):
+                Escape --- (Already caught, to quit.)
+                CapsLock --- Remapped to Control, for me at least.
+                F1--F12 --- Non-standard, but useful for experts' customization macros?
+                Modifiers (??): LCtrl, LShift, LAlt, LGui, RCtrl, RShift, RAlt, RGui
                 */
                 keycode => {
                     info!("Unrecognized key code, ignoring event: {:?}", keycode);

--- a/src/bin/ic-gt.rs
+++ b/src/bin/ic-gt.rs
@@ -461,7 +461,7 @@ async fn do_update_task(
         if let ServerCall::FlushQuit = sc {
             return Ok(());
         };
-        let rr = server_call(&cfg, sc).await?;
+        server_call(&cfg, sc).await?;
         remote_out.send(()).unwrap();
     }
 }

--- a/src/bin/ic-gt.rs
+++ b/src/bin/ic-gt.rs
@@ -302,10 +302,11 @@ fn translate_system_event(event: &SysEvent) -> Option<event::Event> {
             keymod,
             ..
         } => {
-            let shift = keymod.contains(sdl2::keyboard::Mod::LSHIFTMOD)
-                || keymod.contains(sdl2::keyboard::Mod::RSHIFTMOD);
             /* Note: The analysis below encodes my US Mac Book Pro keyboard, almost completely. */
             /* Longer-term, we need a more complex design to handle other mappings and corresponding keyboard variations. */
+
+            let shift = keymod.contains(sdl2::keyboard::Mod::LSHIFTMOD)
+                || keymod.contains(sdl2::keyboard::Mod::RSHIFTMOD);
             let key = match &kc {
                 Keycode::Tab => "Tab".to_string(),
                 Keycode::Space => " ".to_string(),

--- a/src/bin/ic-gt.rs
+++ b/src/bin/ic-gt.rs
@@ -304,6 +304,8 @@ fn translate_system_event(event: &SysEvent) -> Option<event::Event> {
         } => {
             let shift = keymod.contains(sdl2::keyboard::Mod::LSHIFTMOD)
                 || keymod.contains(sdl2::keyboard::Mod::RSHIFTMOD);
+            /* Note: The analysis below encodes my US Mac Book Pro keyboard, almost completely. */
+            /* Longer-term, we need a more complex design to handle other mappings and corresponding keyboard variations. */
             let key = match &kc {
                 Keycode::Tab => "Tab".to_string(),
                 Keycode::Space => " ".to_string(),


### PR DESCRIPTION
Fix issues that frequently come up in simple demos

Logging:  
 - Before: Default log level was too high
 - Now: New default level is "warn"; most messages are "info" and now are suppressed, as desired.

Replica lock up (serious, long-standing issue):
 - Before: If used too long, or too aggressively, the replica would simply stop responding
 - Now: Avoid creating more than the minimal keys (two agents, one per async "task"), rather than one per view request (!).

Notably, the behavior of the demo no longer freezes the replica.  This is a very welcome change!

Also, this change is a strong indication that the replica (or agent logic?) does not handle creating too many keys before something goes wrong.  It's also possible that some library runs out of entropy, or something hits some other resource threshold somewhere (?).  More investigation is needed.