### PR TITLE
Fix: Release tagged commits only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 on:
   push:
-   - '*'
+    tags:
+      - '*'
 
 jobs:
   publish_Mac:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 on:
   push:
+   - '*'
 
 jobs:
   publish_Mac:


### PR DESCRIPTION
Fix the over-active CI script that keeps creating releases for every git event.