### PR TITLE
Feats: Clipboard events ("ClipCan" demo), and local events dump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,12 +69,6 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-
-[[package]]
-name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
@@ -249,15 +243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags 1.2.1",
-]
-
-[[package]]
 name = "codespan-reporting"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,7 +342,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -937,7 +922,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "hashbrown",
 ]
 
@@ -1119,7 +1104,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -1205,23 +1190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
-name = "num"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
-dependencies = [
- "num-integer",
- "num-iter",
- "num-traits 0.2.14",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -1232,7 +1206,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -1243,7 +1217,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-traits 0.2.14",
 ]
 
@@ -1253,7 +1227,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -1283,7 +1257,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -1356,7 +1330,7 @@ version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -1597,44 +1571,15 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.7",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha 0.2.2",
+ "rand_chacha",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
+ "rand_hc",
 ]
 
 [[package]]
@@ -1673,73 +1618,11 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1757,7 +1640,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -1960,26 +1843,25 @@ dependencies = [
 
 [[package]]
 name = "sdl2"
-version = "0.32.2"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d051a07231e303f5f719da78cb6f7394f6d5b54f733aef5b0b447804a83edd7b"
+checksum = "fcbb85f4211627a7291c83434d6bbfa723e28dcaa53c7606087e3c61929e4b9c"
 dependencies = [
  "bitflags 1.2.1",
  "lazy_static",
  "libc",
- "num",
- "rand 0.6.5",
  "sdl2-sys",
 ]
 
 [[package]]
 name = "sdl2-sys"
-version = "0.32.6"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e71125077d297d57e4c1acfe8981b5bdfbf5a20e7b589abfdcb33bf1127f86"
+checksum = "28d81feded049b9c14eceb4a4f6d596a98cebbd59abdba949c5552a015466d33"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
+ "version-compare",
 ]
 
 [[package]]
@@ -2493,6 +2375,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version-compare"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d63556a25bae6ea31b52e640d7c41d1ab27faba4ccb600013837a3d0b3994ca1"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_cbor = "0.9"
 serde_json = "1.0"
-sdl2 = "0.32"
+sdl2 = "0.34.3"
 tokio = "0.2.22"
 delay = "0.3.0"
 num-bigint = "0.2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,12 @@ name = "icmt"
 version = "0.1.0"
 authors = ["Matthew A Hammer <pubmah@nym.hush.com>"]
 edition = "2018"
+description = "The Internet Computer Mini Terminal.  Live input and output for IC canisters."
+homepage = "https://docs.rs/icmt"
+documentation = "https://docs.rs/icmt"
+repository = "https://github.com/matthewhammer/ic-mini-terminal"
+license = "Apache-2.0"
+readme = "README.md"
 
 [dependencies]
 chrono = "0.4"

--- a/src/bin/ic-mt.rs
+++ b/src/bin/ic-mt.rs
@@ -605,8 +605,6 @@ async fn local_event_loop(ctx: ConnectCtx) -> Result<(), IcmtError> {
                 event::Event::ClipBoard(text) => {
                     info!("ClipBoard: {}", text);
                     dirty_flag = true;
-                    view_events.push(skip_event(&ctx));
-                    dump_events.push(skip_event(&ctx));
                     let ev = event::EventInfo {
                         user_info: event::UserInfo {
                             user_name: ctx.cfg.user_info.0.clone(),

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -1,0 +1,58 @@
+/// Errors from the mini terminal, or its subcomponents
+#[derive(Debug, Clone)]
+pub enum IcmtError {
+    Candid(std::sync::Arc<candid::Error>),
+    Agent(), /* Clone => Agent(ic_agent::AgentError) */
+    String(String),
+    Engiffen(), /* Clone => engiffen::Error */
+    RingKeyRejected(ring::error::KeyRejected),
+    RingUnspecified(ring::error::Unspecified),
+}
+impl std::convert::From<ic_agent::AgentError> for IcmtError {
+    fn from(_ae: ic_agent::AgentError) -> Self {
+        /*IcmtError::Agent(ae)*/
+        IcmtError::Agent()
+    }
+}
+
+impl std::convert::From<candid::Error> for IcmtError {
+    fn from(e: candid::Error) -> Self {
+        IcmtError::Candid(std::sync::Arc::new(e))
+    }
+}
+
+impl<T> std::convert::From<std::sync::mpsc::SendError<T>> for IcmtError {
+    fn from(_s: std::sync::mpsc::SendError<T>) -> Self {
+        IcmtError::String("send error".to_string())
+    }
+}
+impl std::convert::From<std::sync::mpsc::RecvError> for IcmtError {
+    fn from(_s: std::sync::mpsc::RecvError) -> Self {
+        IcmtError::String("recv error".to_string())
+    }
+}
+impl std::convert::From<std::io::Error> for IcmtError {
+    fn from(_s: std::io::Error) -> Self {
+        IcmtError::String("IO error".to_string())
+    }
+}
+impl std::convert::From<String> for IcmtError {
+    fn from(s: String) -> Self {
+        IcmtError::String(s)
+    }
+}
+impl std::convert::From<ring::error::KeyRejected> for IcmtError {
+    fn from(r: ring::error::KeyRejected) -> Self {
+        IcmtError::RingKeyRejected(r)
+    }
+}
+impl std::convert::From<ring::error::Unspecified> for IcmtError {
+    fn from(r: ring::error::Unspecified) -> Self {
+        IcmtError::RingUnspecified(r)
+    }
+}
+impl std::convert::From<engiffen::Error> for IcmtError {
+    fn from(_e: engiffen::Error) -> Self {
+        IcmtError::Engiffen()
+    }
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -5,5 +5,6 @@ extern crate serde;
 extern crate serde_bytes;
 //extern crate candid_derive;
 
+pub mod error;
 pub mod keyboard;
 pub mod types;

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -72,6 +72,8 @@ pub mod event {
         MouseDown(super::render::Pos),
         #[serde(rename(serialize = "windowSize"))]
         WindowSize(super::render::Dim),
+        #[serde(rename(serialize = "clipBoard"))]
+        ClipBoard(String),
     }
     #[derive(Clone, Debug, CandidType, Deserialize, Hash, PartialEq, Eq)]
     pub struct KeyEventInfo {


### PR DESCRIPTION
- Clipboard events (from all local activity!) -- not creepy if the user wants to monitor and log their own clipboard, or use it as an explicit communication channel for uploading meaningful strings to their IC canister application(s)
- Dump all events to disk, for later inspection or replay
- Code organization: Moving some stuff into library (error definitions)