### PR TITLE
Responsivity improvement: swap view and update steps

### DIFF
--- a/src/bin/ic-mt.rs
+++ b/src/bin/ic-mt.rs
@@ -1,5 +1,5 @@
-extern crate garcon;
 extern crate futures;
+extern crate garcon;
 extern crate ic_agent;
 extern crate ic_types;
 extern crate icmt;
@@ -64,13 +64,14 @@ async fn create_agent(url: &str) -> IcmtResult<Agent> {
     let rng = SystemRandom::new();
     let pkcs8_bytes = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng)?;
     let key_pair = ring::signature::Ed25519KeyPair::from_pkcs8(pkcs8_bytes.as_ref())?;
-    let ident = ic_agent::identity::BasicIdentity::from_key_pair(key_pair);    
+    let ident = ic_agent::identity::BasicIdentity::from_key_pair(key_pair);
     let agent = Agent::builder()
         .with_url(url)
         .with_identity(ident)
         .build()?;
     info!("built agent.");
-    if true { // to do -- CLI switch.
+    if true {
+        // to do -- CLI switch.
         agent.fetch_root_key().await?;
     }
     info!("got root key.");
@@ -553,7 +554,6 @@ async fn local_event_loop(ctx: ConnectCtx) -> Result<(), IcmtError> {
             }
         };
 
-
         // attend to next batch of local events, and loop everything above
         continue 'running;
     }
@@ -745,6 +745,6 @@ async fn main() -> IcmtResult<()> {
             };
             run(cfg).await?;
         }
-    };    
+    };
     Ok(())
 }

--- a/src/lib/draw.rs
+++ b/src/lib/draw.rs
@@ -1,6 +1,6 @@
 //! Draw.
 
-use log::{trace, warn, error};
+use log::{error, trace, warn};
 
 use crate::{
     color::*,
@@ -118,12 +118,10 @@ pub async fn draw<T: RenderTarget>(
                 warn!("unrecognized redraw elements {:?}", elms);
             }
         }
-        graphics::Result::Err(opt_message) => {
-            match opt_message {
-                None => error!("Error result from server. No message."),
-                Some(ref m) => error!("Error message from server: {}", m),
-            }
-        }
+        graphics::Result::Err(opt_message) => match opt_message {
+            None => error!("Error result from server. No message."),
+            Some(ref m) => error!("Error message from server: {}", m),
+        },
     };
     canvas.present();
     // to do -- if enabled, dump canvas as .BMP file to next output image file in the stream that we are producing

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -236,7 +236,7 @@ pub mod graphics {
         #[serde(rename = "rect")]
         Rect(Rect, Fill),
         #[serde(rename = "node")]
-        Node(Box<Node>)
+        Node(Box<Node>),
     }
     /// Elements
     pub type Elms = Vec<Elm>;


### PR DESCRIPTION
Swaps view and update steps in the main thread's attendance to the subordinate tasks.  Now, view is first, then update.  (Before, they were reversed).

Seems (much) more responsive now with respect to repainting.

Need better measurements, and benchmarks, to be certain in the future.