### PR TITLE
Fix: more responsive drawing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
-
-[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,28 +94,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6736e2428df2ca2848d846c43e88745121a6654696e349ce0054a420815a7409"
 
 [[package]]
-name = "binread"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a883c66db6f3c86b19210ceed1b2b18de64b617c92cb0f0bc90b8c05f18dba87"
-dependencies = [
- "binread_derive",
- "lazy_static",
-]
-
-[[package]]
-name = "binread_derive"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c575d9a28eb4c2d61747b23d50271c6699b941448c35a738af35267f90b3d4d2"
-dependencies = [
- "either",
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "syn 1.0.73",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,21 +149,20 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "candid"
-version = "0.7.3"
-source = "git+https://github.com/dfinity/candid?branch=master#21735b9cb824f1a4049e5be9c16feedff5c19f05"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65f05b872d010281c905c4e6ff2079c1341d1e527e05f3bfab88d49ea3269def"
 dependencies = [
- "anyhow",
- "binread",
  "byteorder",
  "candid_derive",
  "codespan-reporting",
  "hex",
- "ic-types 0.2.0",
+ "ic-types",
  "lalrpop",
  "lalrpop-util",
  "leb128",
  "logos",
- "num-bigint 0.4.0",
+ "num-bigint 0.3.2",
  "num-traits 0.2.14",
  "num_enum",
  "paste",
@@ -203,8 +174,9 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.4.5"
-source = "git+https://github.com/dfinity/candid?branch=master#21735b9cb824f1a4049e5be9c16feedff5c19f05"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7232a5dd836d83ae9ffd79061b42d729afab6f11bfaba7dc2a82575b686ae2"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.27",
@@ -214,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cfg-if"
@@ -260,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "6e0762455306b1ed42bc651ef6a2197aabda5e1d4a43c34d5eab5c1a3634e81d"
 dependencies = [
  "termcolor",
  "unicode-width",
@@ -844,7 +816,7 @@ dependencies = [
  "garcon",
  "hex",
  "http",
- "ic-types 0.1.5",
+ "ic-types",
  "leb128",
  "mime",
  "openssl",
@@ -878,21 +850,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f0b1f1517d697f67a8b5ad558ef6b9372ed1fc5ab669a519d7fa1837e8f88a"
-dependencies = [
- "base32",
- "crc32fast",
- "hex",
- "serde",
- "serde_bytes",
- "sha2",
- "thiserror",
-]
-
-[[package]]
 name = "icmt"
 version = "0.1.0"
 dependencies = [
@@ -905,7 +862,7 @@ dependencies = [
  "garcon",
  "hex",
  "ic-agent",
- "ic-types 0.1.5",
+ "ic-types",
  "log",
  "num-bigint 0.2.6",
  "num-traits 0.2.14",
@@ -966,9 +923,9 @@ checksum = "d1238524675af3938a7c74980899535854b88ba07907bb1c944abe5b8fc437e5"
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1211,6 +1168,17 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-bigint"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
@@ -1281,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b45a5c2ac4dd696ed30fa6b94b057ad909c7b7fc2e0d0808192bced894066"
+checksum = "e5adf0198d427ee515335639f275e806ca01acf9f07d7cf14bb36a10532a6169"
 dependencies = [
  "derivative",
  "num_enum_derive",
@@ -1291,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0fd9eba1d5db0994a239e09c1be402d35622277e35468ba891aa5e3188ce7e"
+checksum = "b1def5a3f69d4707d8a040b12785b98029a39e8c610ae685c7f6265669767482"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.27",
@@ -1473,10 +1441,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
 dependencies = [
+ "thiserror",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,12 @@ ring = "0.16.15"
 engiffen = "0.8.1"
 ic-agent = "0.5.0"
 ic-types = "0.1.3"
-#candid = "0.6.11"
+candid = "0.6"
 ron = "*"
 
-[dependencies.candid]
-git = "https://github.com/dfinity/candid"
-branch = "master"
+#[dependencies.candid]
+#git = "https://github.com/dfinity/candid"
+#branch = "master"
 
 [lib]
 name = "icmt"

--- a/src/lib/cli.rs
+++ b/src/lib/cli.rs
@@ -6,6 +6,8 @@ use structopt::StructOpt;
 use ic_agent::Agent;
 use ic_types::Principal;
 
+use std::path::PathBuf;
+
 /// Internet Computer Mini Terminal (ic-mt)
 #[derive(StructOpt, Debug, Clone)]
 #[structopt(name = "ic-mt", raw(setting = "clap::AppSettings::DeriveDisplayOrder"))]
@@ -72,6 +74,7 @@ pub struct ConnectCtx {
     pub cfg: ConnectCfg,
     pub agent: Agent,
     pub canister_id: Principal,
+    pub data_path: PathBuf,
 }
 
 /// Connection configuration


### PR DESCRIPTION
- measure and record times for view task
- Yan confirms that Candid decoding is very expensive now; subtype checking is new.
- revert to using candid 0.6, and [avoid costly subtyping check introduced in 0.7](https://github.com/dfinity/candid/issues/240#issuecomment-8792811720).
