### PR TITLE
Reorg: Make room for web-based mini terminal.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,34 +5,6 @@ on:
       - master
   pull_request:
 jobs:
-  Motoko_icmt_package_all_examples:
-    name: Motoko icmt package
-    runs-on: ubuntu-latest
-    env:
-      DFX_VERSION: 0.7.2
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install
-      run: |
-        echo y | DFX_VERSION=$DFX_VERSION bash -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
-        echo "/home/runner/bin" >> $GITHUB_PATH
-        dfx cache install
-        ./scripts/vessel-install.sh
-    - name: Build_and_deploy_all_examples
-      run: |
-        dfx start --background
-        dfx deploy --no-wallet
-    - name: Tests
-      run: echo "to do"
-    - name: Docs_build
-      run: /home/runner/.cache/dfinity/versions/$DFX_VERSION/mo-doc
-    - name: Docs_upload
-      uses: JamesIves/github-pages-deploy-action@releases/v3
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages
-        FOLDER: docs/
-
   build_mac_release:
     name: Build ic-mt for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dbbb57365263e881e805dc77d94697c9118fd94d8da011240555aa7b23445bd"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+dependencies = [
+ "cfg-if 0.1.10",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,7 +860,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "icmt"
+name = "icmt-web"
+version = "0.1.0"
+dependencies = [
+ "icmt_core",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
+]
+
+[[package]]
+name = "icmt_core"
+version = "0.1.0"
+dependencies = [
+ "candid",
+ "ic-types",
+ "num-bigint 0.2.6",
+ "num-traits 0.2.14",
+ "serde",
+ "serde_bytes",
+ "serde_cbor 0.9.0",
+ "serde_json",
+]
+
+[[package]]
+name = "icmt_sdl2"
 version = "0.1.0"
 dependencies = [
  "candid",
@@ -1811,6 +1846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scoped_threadpool"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2476,6 +2517,30 @@ name = "wasm-bindgen-shared"
 version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cab416a9b970464c2882ed92d55b0c33046b08e0bdc9d59b3b718acd4e1bae8"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4543fc6cf3541ef0d98bf720104cc6bd856d7eba449fd2aa365ef4fed0e782"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
 members = [
+    "icmt-core",
+    "icmt-web",
     "icmt-sdl2",
 ]

--- a/README.md
+++ b/README.md
@@ -85,3 +85,4 @@ We often write these applications in [Motoko](https://sdk.dfinity.org/docs/langu
  * Fantasy console [PICO-8](https://www.lexaloffle.com/pico-8.php) ([PICO-8 Manual](https://www.lexaloffle.com/pico8_manual.txt)).
  * [Languages of Play: Towards semantic foundations for game interfaces](https://arxiv.org/abs/1703.05410) ([Chris Martens](https://sites.google.com/ncsu.edu/cmartens) and Matthew Hammer, March 2017).
  * [Lock-Step Simulation Is Child’s Play (Experience Report)](https://www.joachim-breitner.de/publications/CodeWorld-ICFP17.pdf) ([Joachim Breitner](https://www.joachim-breitner.de/blog) and [Chris Smith](https://github.com/cdsmith))
+

--- a/icmt-core/Cargo.toml
+++ b/icmt-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "icmt_sdl2"
+name = "icmt_core"
 version = "0.1.0"
 authors = ["Matthew A Hammer <pubmah@nym.hush.com>"]
 edition = "2018"
@@ -11,36 +11,18 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-chrono = "0.4"
-clap = "2.33"
-structopt = "0.2"
-log = "0.4"
-env_logger = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_cbor = "0.9"
 serde_json = "1.0"
-sdl2 = "0.34.3"
-tokio = { version = "1", features = ["full"] }
-garcon = "0.2.3"
-hex = "0.4.2"
 num-bigint = "0.2.6"
 num-traits = "0.2.6"
-futures = "0.3.5"
-ring = "0.16.15"
-engiffen = "0.8.1"
-ic-agent = "0.5.0"
 ic-types = "0.1.3"
 candid = "0.6"
-ron = "*"
-
-#[dependencies.candid]
-#git = "https://github.com/dfinity/candid"
-#branch = "master"
 
 [lib]
-name = "icmt_sdl2"
-path = "lib/mod.rs"
+name = "icmt_core"
+path = "src/mod.rs"
 test = true            # Is tested by default.
 doctest = true         # Documentation examples are tested by default.
 bench = true           # Is benchmarked by default.
@@ -51,7 +33,3 @@ harness = true         # Use libtest harness.
 edition = "2018"       # The edition of the target.
 crate-type = ["lib"]   # The crate types to generate.
 required-features = [] # Features required to build this target (N/A for lib).
-
-[[bin]]
-name = "ic-mt"
-path = "bin/ic-mt.rs"

--- a/icmt-core/src/mod.rs
+++ b/icmt-core/src/mod.rs
@@ -1,0 +1,9 @@
+//! Mini-terminal utility library.
+//!
+//! (Note: Public modules and types for demonstration purposes; all are subject to change.)
+
+extern crate candid;
+extern crate serde;
+extern crate serde_bytes;
+
+pub mod types;

--- a/icmt-core/src/types.rs
+++ b/icmt-core/src/types.rs
@@ -1,0 +1,163 @@
+//! Types of data sent to and from the game service canister.
+
+use num_traits::cast::ToPrimitive;
+pub type Nat = candid::Nat;
+
+pub fn nat_ceil(n: &Nat) -> u32 {
+    n.0.to_u32().unwrap()
+}
+
+pub fn byte_ceil(n: &Nat) -> u8 {
+    match n.0.to_u8() {
+        Some(byte) => byte,
+        None => 255,
+    }
+}
+
+/// Terminal events, locally buffered as input to service.
+pub mod event {
+    use candid::{CandidType, Deserialize, Nat};
+
+    /// User information for identifying events' user origins.
+    #[derive(Clone, Debug, CandidType, Deserialize, Hash, PartialEq, Eq)]
+    pub struct UserInfo {
+        #[serde(rename = "userName")]
+        pub user_name: String,
+        #[serde(rename = "textColor")]
+        pub text_color: ((Nat, Nat, Nat), (Nat, Nat, Nat)),
+    }
+
+    /// Event information (full record).
+    #[derive(Clone, Debug, CandidType, Deserialize, Hash, PartialEq, Eq)]
+    pub struct EventInfo {
+        #[serde(rename = "userInfo")]
+        pub user_info: UserInfo,
+        pub nonce: Option<Nat>,
+        #[serde(rename = "dateTimeUtc")]
+        pub date_time_utc: String,
+        #[serde(rename = "dateTimeLocal")]
+        pub date_time_local: String,
+        pub event: Event,
+    }
+    /// Event(-specific information).
+    #[derive(Clone, Debug, CandidType, Deserialize, Hash, PartialEq, Eq)]
+    pub enum Event {
+        #[serde(rename = "skip")]
+        Skip,
+        #[serde(rename = "quit")]
+        Quit,
+        #[serde(rename = "keyDown")]
+        KeyDown(Vec<KeyEventInfo>),
+        #[serde(rename = "mouseDown")]
+        MouseDown(super::graphics::Pos),
+        #[serde(rename = "windowSize")]
+        WindowSize(super::graphics::Dim),
+        #[serde(rename = "clipBoard")]
+        ClipBoard(String),
+    }
+    /// Keyboard event information.
+    #[derive(Clone, Debug, CandidType, Deserialize, Hash, PartialEq, Eq)]
+    pub struct KeyEventInfo {
+        pub key: String,
+        pub alt: bool,
+        pub ctrl: bool,
+        pub meta: bool,
+        pub shift: bool,
+    }
+}
+
+/// Terminal gaphics, service output to terminal.
+pub mod graphics {
+    use super::Nat;
+    //use super::lang::Name;
+    use candid::{CandidType, Deserialize};
+
+    /// Color
+    pub type Color = (Nat, Nat, Nat);
+
+    /// (Update message's) request for graphics.
+    #[derive(Debug, Clone, CandidType, Deserialize, Eq, PartialEq, Hash)]
+    pub enum Request {
+        #[serde(rename = "none")]
+        None,
+        #[serde(rename = "all")]
+        All(Dim),
+        #[serde(rename = "last")]
+        Last(Dim),
+    }
+
+    /// Dimension
+    #[derive(Clone, Debug, CandidType, Deserialize, Hash, PartialEq, Eq)]
+    pub struct Dim {
+        pub width: Nat,
+        pub height: Nat,
+    }
+    /// Position
+    #[derive(Clone, Debug, CandidType, Deserialize, Hash, PartialEq, Eq)]
+    pub struct Pos {
+        pub x: Nat,
+        pub y: Nat,
+    }
+    /// Rectangle
+    #[derive(Clone, Debug, CandidType, Deserialize, Hash, PartialEq, Eq)]
+    pub struct Rect {
+        pub pos: Pos,
+        pub dim: Dim,
+    }
+    impl Rect {
+        pub fn new(x: Nat, y: Nat, w: Nat, h: Nat) -> Rect {
+            Rect {
+                pos: Pos { x, y },
+                dim: Dim {
+                    width: w,
+                    height: h,
+                },
+            }
+        }
+    }
+    #[derive(Clone, Debug, CandidType, Deserialize, Hash, PartialEq, Eq)]
+    pub struct Node {
+        pub rect: Rect,
+        pub fill: Fill,
+        pub elms: Elms,
+    }
+    /// Fill
+    #[derive(Clone, Debug, CandidType, Deserialize, Hash, PartialEq, Eq)]
+    pub enum Fill {
+        #[serde(rename = "open")]
+        Open(Color, Nat), // border width
+        #[serde(rename = "closed")]
+        Closed(Color),
+        #[serde(rename = "none")]
+        None,
+    }
+    /// Element
+    #[derive(Clone, Debug, CandidType, Deserialize, Hash, PartialEq, Eq)]
+    pub enum Elm {
+        #[serde(rename = "rect")]
+        Rect(Rect, Fill),
+        #[serde(rename = "node")]
+        Node(Box<Node>),
+    }
+    /// Elements
+    pub type Elms = Vec<Elm>;
+    /// Named elements
+    pub type NamedElms = Vec<(String, Elm)>;
+
+    /// Output
+    #[derive(Clone, Debug, CandidType, Deserialize, Hash, PartialEq, Eq)]
+    pub enum Out {
+        #[serde(rename = "draw")]
+        Draw(Elm),
+        #[serde(rename = "redraw")]
+        Redraw(NamedElms),
+    }
+    /// Result
+    #[derive(Clone, Debug, CandidType, Deserialize, Hash, PartialEq, Eq)]
+    pub enum Result {
+        #[serde(rename = "ok")]
+        Ok(Out),
+        #[serde(rename = "err")]
+        Err(Option<String>),
+    }
+}

--- a/icmt-sdl2/bin/ic-mt.rs
+++ b/icmt-sdl2/bin/ic-mt.rs
@@ -2,7 +2,7 @@ extern crate futures;
 extern crate garcon;
 extern crate ic_agent;
 extern crate ic_types;
-extern crate icmt;
+extern crate icmt_sdl2;
 extern crate num_traits;
 extern crate sdl2;
 extern crate serde;
@@ -34,7 +34,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 use tokio::task;
 
-use icmt::{
+use icmt_sdl2::{
     cli::*,
     draw::*,
     error::*,

--- a/icmt-web/Cargo.toml
+++ b/icmt-web/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "icmt-web"
+version = "0.1.0"
+authors = ["Matthew Hammer <matthew.hammer@gmail.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2.63"
+icmt_core = { path = "../icmt-core" }
+wasm-bindgen-futures = "0.4.24"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.13"
+
+[dependencies.web-sys]
+version = "0.3.4"
+features = [  
+  'console',
+  'CanvasRenderingContext2d',
+  'Document',
+  'Element',
+  'HtmlCanvasElement',
+  'HtmlElement',
+  'Node',
+  'Window',
+  'KeyboardEvent',
+]
+
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/icmt-web/src/lib.rs
+++ b/icmt-web/src/lib.rs
@@ -1,0 +1,57 @@
+use wasm_bindgen::prelude::*;
+
+use std::f64;
+
+use wasm_bindgen::JsCast;
+use web_sys::{self, console};
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+extern crate icmt_core;
+use icmt_core::{
+    types::{
+        event::{self, Event, KeyEventInfo}, graphics, nat_ceil
+    },
+};
+
+fn console_log(m: String) {
+    let message: JsValue = m.as_str().clone().into();
+    console::log_1(&message);
+}
+
+// Called when the wasm module is instantiated
+#[wasm_bindgen(start)]
+pub async fn main() -> Result<(), JsValue> {
+
+    let closure = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
+
+        match format!("{}", event.key()).as_str() {
+            "Tab" | "Escape" | "ArrowUp" | "ArrowDown" | "ArrowLeft" | "ArrowRight" | " "
+                | "Backspace" => {
+                    let ev =
+                        Event::KeyDown(vec![KeyEventInfo {
+                            key: event.key(),
+                            alt: event.alt_key(),
+                            ctrl: event.ctrl_key(),
+                            shift: event.shift_key(),
+                            meta: event.meta_key(),
+                        }]);
+                    drop(ev)
+                }
+            key => {
+                console_log(format!("unrecognized key: {}", key));                
+            }
+        };
+
+    }) as Box<dyn FnMut(_)>);
+
+    let document = web_sys::window().unwrap().document().unwrap();
+    document.set_onkeydown(Some(closure.as_ref().unchecked_ref()));
+    //document.set_onkeypress(Some(closure.as_ref().unchecked_ref()));
+    //document.set_onkeyup(Some(closure.as_ref().unchecked_ref()));
+    //document.set_oninput(Some(closure.as_ref().unchecked_ref()));
+    closure.forget();
+
+    Ok(())
+}


### PR DESCRIPTION
The current tool uses sdl2 and is specific to local execution on a desktop machine, or a laptop.  This limits the use cases, and the potential users.

To broaden the use of `icmt`, this PR introduces a stubs for a web-based version, and re-organizes the Rust crate to make room for additional ones.

(Replaces and subsumes earlier incomplete efforts in #71).