### PR TITLE
Feature: Read pem files, like that of dfx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ dependencies = [
  "log",
  "num-bigint 0.2.6",
  "num-traits 0.2.14",
+ "pem",
  "ring",
  "ron",
  "sdl2",
@@ -873,6 +874,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor 0.9.0",
  "serde_json",
+ "shellexpand",
  "structopt",
  "tokio",
 ]
@@ -1962,6 +1964,15 @@ dependencies = [
  "cpufeatures",
  "digest",
  "opaque-debug",
+]
+
+[[package]]
+name = "shellexpand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
+dependencies = [
+ "dirs-next",
 ]
 
 [[package]]

--- a/icmt-sdl2/Cargo.toml
+++ b/icmt-sdl2/Cargo.toml
@@ -33,6 +33,8 @@ ic-agent = "0.5.0"
 ic-types = "0.1.3"
 candid = "0.6"
 ron = "*"
+shellexpand = "2.1.0"
+pem = "0.8"
 
 #[dependencies.candid]
 #git = "https://github.com/dfinity/candid"

--- a/icmt-sdl2/bin/ic-mt.rs
+++ b/icmt-sdl2/bin/ic-mt.rs
@@ -15,7 +15,7 @@ extern crate structopt;
 use structopt::StructOpt;
 
 use candid::Decode;
-use ic_agent::{Agent};
+use ic_agent::Agent;
 use ic_types::Principal;
 
 use candid::Nat;
@@ -26,7 +26,7 @@ use sdl2::keyboard::Keycode;
 use sdl2::render::{Canvas, RenderTarget};
 use sdl2::surface::Surface;
 use std::fs;
-use std::fs::{OpenOptions};
+use std::fs::OpenOptions;
 use std::io;
 use std::io::Write;
 use std::path::PathBuf;
@@ -60,22 +60,19 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 async fn create_agent(url: &str, pem_file: &Option<String>) -> IcmtResult<Agent> {
     use ring::signature::Ed25519KeyPair;
-    let keypair =
-        if let Some(pem_path) = pem_file {
-            let path = resolve_path(&pem_path)?;
-            let bytes =
-                std::fs::read(&path)?;
-            info!("Parsing pem file {:?}", path);
-            let pem = pem::parse(&bytes)?;
-            info!("Successfully parsed pem file {:?}", path);
-            pem.contents
-        } else {
-            let rng = ring::rand::SystemRandom::new();
-            Ed25519KeyPair::generate_pkcs8(&rng)?.as_ref().to_vec()
-        };
-    let identity = ic_agent::identity::BasicIdentity::from_key_pair(
-        Ed25519KeyPair::from_pkcs8(&keypair)?,
-    );
+    let keypair = if let Some(pem_path) = pem_file {
+        let path = resolve_path(&pem_path)?;
+        let bytes = std::fs::read(&path)?;
+        info!("Parsing pem file {:?}", path);
+        let pem = pem::parse(&bytes)?;
+        info!("Successfully parsed pem file {:?}", path);
+        pem.contents
+    } else {
+        let rng = ring::rand::SystemRandom::new();
+        Ed25519KeyPair::generate_pkcs8(&rng)?.as_ref().to_vec()
+    };
+    let identity =
+        ic_agent::identity::BasicIdentity::from_key_pair(Ed25519KeyPair::from_pkcs8(&keypair)?);
     let agent = Agent::builder()
         .with_url(url)
         .with_identity(identity)
@@ -775,7 +772,7 @@ async fn main() -> IcmtResult<()> {
                 replica_url,
                 cli_opt,
                 user_kind,
-                pem_file:None,
+                pem_file: None,
             };
             run(cfg).await?;
         }
@@ -787,11 +784,7 @@ async fn main() -> IcmtResult<()> {
             let user_info: UserInfoCli = {
                 (
                     format!("Guest-{}", Local::now().to_rfc3339()),
-                    (
-                        Nat::from(255),
-                        Nat::from(255),
-                        Nat::from(255),
-                    ),
+                    (Nat::from(255), Nat::from(255), Nat::from(255)),
                 )
             };
             let user_kind = UserKind::Local(user_info);

--- a/icmt-sdl2/lib/cli.rs
+++ b/icmt-sdl2/lib/cli.rs
@@ -3,7 +3,7 @@
 use clap::Shell;
 use structopt::StructOpt;
 
-use ic_agent::{Agent};
+use ic_agent::Agent;
 use ic_types::Principal;
 
 use std::path::PathBuf;
@@ -75,7 +75,6 @@ pub struct ConnectCtx {
     pub canister_id: Principal,
     pub data_path: PathBuf,
 }
-
 
 /// Connection configuration
 #[derive(Debug, Clone)]

--- a/icmt-sdl2/lib/cli.rs
+++ b/icmt-sdl2/lib/cli.rs
@@ -3,7 +3,7 @@
 use clap::Shell;
 use structopt::StructOpt;
 
-use ic_agent::Agent;
+use ic_agent::{Agent};
 use ic_types::Principal;
 
 use std::path::PathBuf;
@@ -51,9 +51,8 @@ pub enum CliCommand {
     Connect {
         replica_url: String,
         canister_id: String,
-        /// Initialization arguments, as a Candid textual value (default is empty tuple).
-        #[structopt(short = "i", long = "user")]
-        user_info_text: String,
+        #[structopt(short = "p", long = "pem-file")]
+        pem_file: Option<String>,
     },
     #[structopt(
         name = "replay",
@@ -64,7 +63,7 @@ pub enum CliCommand {
         canister_id: String,
         events_file_path: String,
         /// Frame size, in number of events, for the replay's update requests.
-        #[structopt(short = "s", long = "frame_size", default_value = "6")]
+        #[structopt(short = "s", long = "frame-size", default_value = "6")]
         frame_size: usize,
     },
 }
@@ -77,6 +76,7 @@ pub struct ConnectCtx {
     pub data_path: PathBuf,
 }
 
+
 /// Connection configuration
 #[derive(Debug, Clone)]
 pub struct ConnectCfg {
@@ -84,4 +84,5 @@ pub struct ConnectCfg {
     pub canister_id: String,
     pub replica_url: String,
     pub user_kind: crate::types::UserKind,
+    pub pem_file: Option<String>,
 }

--- a/icmt-sdl2/lib/error.rs
+++ b/icmt-sdl2/lib/error.rs
@@ -6,7 +6,7 @@ use log::error;
 pub type IcmtResult<X> = Result<X, IcmtError>;
 
 /// Errors from the mini terminal, or its subcomponents.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum IcmtError {
     Candid(std::sync::Arc<candid::Error>),
     Agent(), /* Clone => Agent(ic_agent::AgentError) */
@@ -15,7 +15,15 @@ pub enum IcmtError {
     RingKeyRejected(ring::error::KeyRejected),
     RingUnspecified(ring::error::Unspecified),
     FromHexError(hex::FromHexError),
+    PemError(pem::PemError),
 }
+
+impl std::convert::From<pem::PemError> for IcmtError {
+    fn from(pe: pem::PemError) -> Self {
+        IcmtError::PemError(pe)
+    }
+}
+
 impl std::convert::From<hex::FromHexError> for IcmtError {
     fn from(fhe: hex::FromHexError) -> Self {
         IcmtError::FromHexError(fhe)


### PR DESCRIPTION
This PR permits connections to re-use existing IC identities (for example, from dfx)

Example:
```
ic-mt -L connect https://ic0.app juud5-raaaa-aaaae-aabaq-cai --pem-file ~/.config/dfx/identity/default/identity.pem
```

Connects using the `default` identity also used by `dfx`.

#### Credits

[Follows example set by from ic-repl](https://github.com/chenyan2002/ic-repl/blob/f0c4dea608284045298fad479422bba735e57ce3/src/command.rs#L96).